### PR TITLE
Added mising "LR" definition to CatalogoTipoCredito.php

### DIFF
--- a/lib/Model/CatalogoTipoCredito.php
+++ b/lib/Model/CatalogoTipoCredito.php
@@ -30,6 +30,7 @@ class CatalogoTipoCredito
     const HE = 'HE';
     const HV = 'HV';
     const LC = 'LC';
+    const LR = 'LR';
     const MC = 'MC';
     const NG = 'NG';
     const PB = 'PB';
@@ -77,6 +78,7 @@ class CatalogoTipoCredito
             self::HE,
             self::HV,
             self::LC,
+            self::LR,
             self::MC,
             self::NG,
             self::PB,


### PR DESCRIPTION
to solve response error:
```
Exception when calling RCC-FS-PLDApi->getReporte: Invalid value for enum '\RCCFSPLD\MX\Client\Model\CatalogoTipoCredito', must be one of: 'AA', 'AB', 'AE', 'AM', 'AR', 'AV', 'BC', 'BL', 'BR', 'CA', 'CC', 'CF', 'CO', 'CP', 'ED', 'EQ', 'FF', 'FI', 'FT', 'GS', 'HB', 'HE', 'HV', 'LC', 'MC', 'NG', 'PB', 'PC', 'PE', 'PG', 'PQ', 'PM', 'PN', 'PP', 'SH', 'TC', 'TD', 'TG', 'TS', 'VR', 'OT', 'NC'
```